### PR TITLE
【U】依赖版本明确，Milvus使用参数添加注释

### DIFF
--- a/deepseek/api/deepseek_api.ipynb
+++ b/deepseek/api/deepseek_api.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "!pip install openai"
+    "!pip install openai==1.82.0"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/deepseek/api/rag_milvus_deepseek.ipynb
+++ b/deepseek/api/rag_milvus_deepseek.ipynb
@@ -32,12 +32,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "9c18d7b4",
-   "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -115,7 +110,7 @@
     }
    ],
    "source": [
-    "!pip install --upgrade \"pymilvus[model]\" openai requests tqdm torch"
+    "!pip install \"pymilvus[model]==2.5.10\" openai==1.82.0 requests==2.32.3 tqdm==4.67.1 torch==2.7.0"
    ]
   },
   {
@@ -402,7 +397,25 @@
    "source": [
     "创建一个具有指定参数的新 collection。\n",
     "\n",
-    "如果我们不指定任何字段信息，Milvus 将自动创建一个默认的 `id` 字段作为主键，以及一个 `vector` 字段来存储向量数据。一个保留的 JSON 字段用于存储非 schema 定义的字段及其值。"
+    "如果我们不指定任何字段信息，Milvus 将自动创建一个默认的 `id` 字段作为主键，以及一个 `vector` 字段来存储向量数据。一个保留的 JSON 字段用于存储非 schema 定义的字段及其值。\n",
+    "\n",
+    "`metric_type` (距离度量类型):\n",
+    "     作用：定义如何计算向量之间的相似程度。\n",
+    "     例如：`IP` (内积) - 值越大通常越相似；`L2` (欧氏距离) - 值越小越相似；`COSINE` (余弦相似度) - 通常转换为距离，值越小越相似。\n",
+    "     选择依据：根据你的嵌入模型的特性和期望的相似性定义来选择。\n",
+    "\n",
+    " `consistency_level` (一致性级别):\n",
+    "     作用：定义数据写入后，读取操作能多快看到这些新数据。\n",
+    "     例如：\n",
+    "         `Strong` (强一致性): 总是读到最新数据，可能稍慢。\n",
+    "         `Bounded` (有界过期): 可能读到几秒内旧数据，性能较好 (默认)。\n",
+    "         `Session` (会话一致性): 自己写入的自己能立刻读到。\n",
+    "         `Eventually` (最终一致性): 最终会读到新数据，但没时间保证，性能最好。\n",
+    "     选择依据：在数据实时性要求和系统性能之间做权衡。\n",
+    "\n",
+    "简单来说：\n",
+    " `metric_type`：怎么算相似。\n",
+    " `consistency_level`：新数据多久能被读到。"
    ]
   },
   {
@@ -787,7 +800,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
依赖版本明确
!pip install openai==1.82.0


!pip install "pymilvus[model]==2.5.10" openai==1.82.0 requests==2.32.3 tqdm==4.67.1 torch==2.7.0

Milvus使用参数添加注释
`metric_type` (距离度量类型):
     作用：定义如何计算向量之间的相似程度。
     例如：`IP` (内积) - 值越大通常越相似；`L2` (欧氏距离) - 值越小越相似；`COSINE` (余弦相似度) - 通常转换为距离，值越小越相似。
     选择依据：根据你的嵌入模型的特性和期望的相似性定义来选择。

 `consistency_level` (一致性级别):
     作用：定义数据写入后，读取操作能多快看到这些新数据。
     例如：
         `Strong` (强一致性): 总是读到最新数据，可能稍慢。
         `Bounded` (有界过期): 可能读到几秒内旧数据，性能较好 (默认)。
         `Session` (会话一致性): 自己写入的自己能立刻读到。
         `Eventually` (最终一致性): 最终会读到新数据，但没时间保证，性能最好。
     选择依据：在数据实时性要求和系统性能之间做权衡。

简单来说：
 `metric_type`：怎么算相似。
 `consistency_level`：新数据多久能被读到。
