### PR TITLE
feat: 修复milvus-lite的版本不一致导致的bug

### DIFF
--- a/deepseek/api/rag_milvus_deepseek.ipynb
+++ b/deepseek/api/rag_milvus_deepseek.ipynb
@@ -108,14 +108,12 @@
       "Requirement already satisfied: coloredlogs in /root/anaconda3/envs/deepseek/lib/python3.13/site-packages (from onnxruntime->pymilvus.model>=0.3.0->pymilvus[model]==2.5.10) (15.0.1)\n",
       "Requirement already satisfied: flatbuffers in /root/anaconda3/envs/deepseek/lib/python3.13/site-packages (from onnxruntime->pymilvus.model>=0.3.0->pymilvus[model]==2.5.10) (25.2.10)\n",
       "Requirement already satisfied: humanfriendly>=9.1 in /root/anaconda3/envs/deepseek/lib/python3.13/site-packages (from coloredlogs->onnxruntime->pymilvus.model>=0.3.0->pymilvus[model]==2.5.10) (10.0)\n",
-      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[0m"
+      "\u001B[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001B[0m\u001B[33m\n",
+      "\u001B[0m"
      ]
     }
    ],
-   "source": [
-    "!pip install \"pymilvus[model]==2.5.10\" openai==1.82.0 requests==2.32.3 tqdm==4.67.1 torch==2.7.0"
-   ]
+   "source": "!pip install \"pymilvus[model]==2.5.10\" \"milvus-lite<2.6\" \"setuptools<81\" openai==1.82.0 requests==2.32.3 tqdm==4.67.1 torch==2.7.0"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
修复function_score问题: 
⏺ SEARCH OK -> 0 2.62 —— search 正常了，function_score 错误消失。

  根因

  版本三连不匹配：
  - pymilvus 2.5.10 配 milvus-lite 3.0（跨大版本）→ search 请求 proto 字段不一致 → function_score AttributeError
  - milvus-lite 2.5.x 依赖 pkg_resources，而 setuptools 81+ 把它移除了
